### PR TITLE
Moved settings from Permalinks to General due to WP #9296

### DIFF
--- a/any-hostname.php
+++ b/any-hostname.php
@@ -45,7 +45,7 @@ class AnyHostname {
 
 		load_plugin_textdomain( 'anyhostname', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-		$this->options_page = version_compare(get_bloginfo('version'), '3.5') < 0 ? 'privacy' : 'permalink';
+		$this->options_page = version_compare(get_bloginfo('version'), '3.5') < 0 ? 'privacy' : 'general';
 
 		$this->load_options();
 		$this->enable_filters();


### PR DESCRIPTION
I was having problems getting the any-hostname settings to save in WP 3.7—it seems there's [a problem](http://core.trac.wordpress.org/ticket/9296) when using register_setting on the Permalinks settings page.

To work around this until it's resolved in WP core, I moved the settings to the General page.
