### PR TITLE
Add a filter to the option "theme_mods_{$theme_slug}"

### DIFF
--- a/any-hostname.php
+++ b/any-hostname.php
@@ -4,7 +4,7 @@ Plugin Name: Any Hostname
 Plugin URI: http://wordpress.org/extend/plugins/any-hostname/
 Description: Alters all WordPress-generated URLs according to the servers current hostname, so that they will always correspond to the actual hostname as entered by the user.
 Author: Simon Fransson
-Version: 1.0.4
+Version: 1.0.5
 Author URI: http://dessibelle.se/
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,9 @@ This section describes how to install the plugin and get it working.
 
 == Changelog ==
 
+= 1.0.5 =
+* Added filter to the option "option_theme_mods_{$current_theme_slug}" to filter the URL to header image and background image when using for example get_header_image() or get_theme_mods() (Thanks to [feedmeastraycat](http://profiles.wordpress.org/feedmeastraycat))*
+
 = 1.0.4 =
 * Due to a [WordPress bug](http://core.trac.wordpress.org/ticket/9296) plugin settings have been moved to Settings / General.
 


### PR DESCRIPTION
I haven't created an issue for this yet. So feel free to use this pull request or implement it in any other way you want to. Or not. :)

This pull request adds a filter to the option "theme_mods_{$current_theme_slug}" so that users can get a filtered url when they use [get_header_image()](http://codex.wordpress.org/Function_Reference/get_header_image), [get_theme_mod()](http://codex.wordpress.org/Function_Reference/get_theme_mod) _(with parameter "header_image" or "header_image_data")_ or [get_theme_mods()](https://codex.wordpress.org/Function_Reference/get_theme_mods).

_Thanks for a great plugin!_
